### PR TITLE
fix: navigation not opening/collapsing on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,7 +22,7 @@
   <nav class="navbar navbar-toggleable navbar-inverse bg-primary">
     <div class="container">
       <!--why did this container draw the search bar to the left-->
-      <button class="navbar-toggler collapsed" type="button" data-toggle="collapse in" data-target="#collapsingNavbar">
+      <button class="navbar-toggler collapsed" type="button" data-toggle="collapse" data-target="#collapsingNavbar">
         <span class="navbar-toggler-icon"></span>
     </button>
       <div class="collapse navbar-collapse" id="collapsingNavbar">

--- a/index.html
+++ b/index.html
@@ -62,7 +62,7 @@
   <script src="https://code.jquery.com/jquery-3.1.1.slim.min.js" integrity="sha384-A7FZj7v+d/sdmMqp/nOQwliLvUsJfDHW+k9Omg/a/EheAdgtzNs3hpfag6Ed950n" crossorigin="anonymous"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/tether/1.4.0/js/tether.min.js" integrity="sha384-DztdAPBWPRXSA/3eYEEUWrWCy7G5KFbe8fFjk5JAIxUYHKkDx6Qin1DkWx51bBrb" crossorigin="anonymous"></script>
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.6/js/bootstrap.min.js" integrity="sha384-vBWWzlZJ8ea9aCX4pEW3rVHjgjt7zpkNpZk+02D9phzyeVkE+jo0ieGizqPLForn" crossorigin="anonymous"></script>
-  <script src="JavaScript.js"></script>
+  <!-- <script src="JavaScript.js"></script> -->
 </body>
 
 </html>


### PR DESCRIPTION
# Overview
Navigation now opens and closes as expected on mobile once collapsed.

# Changed

- Remove the `in` class applied to the toggle/hamburger button. This was causing the scripts to think it was already open. 
- Remove an empty script includes producing a console warning that might of also caused other javascript related issues.